### PR TITLE
Ccp0101/minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ genome_designer/snpEff_summary.html
 # IDE config files
 *.sublime-project
 *.sublime-workspace
+
+# Virtualenv
+venv

--- a/genome_designer/setup.py
+++ b/genome_designer/setup.py
@@ -153,7 +153,7 @@ def setup_jbrowse():
 if __name__ == '__main__':
 
     # Placeholder for a more comprehensive command line arg parsing:
-    if len(sys.argv) and sys.argv[1] == 'jbrowse':
+    if len(sys.argv) > 1 and sys.argv[1] == 'jbrowse':
         setup_jbrowse()
     else:
         setup()


### PR DESCRIPTION
fix genome-designer-v2/setup.py to install tools properly. ignore venv directory as well. 
