### PR TITLE
Ref Genome header gap and field select scroll

### DIFF
--- a/genome_designer/main/static/css/base.css
+++ b/genome_designer/main/static/css/base.css
@@ -437,3 +437,9 @@ div.dataTables_paginate ul.pagination {
   font-weight: bold;
   margin-left: 10px;
 }
+
+#gd-filter-key-modal .modal-content{
+  height: 92vh;
+  overflow: auto;
+}
+

--- a/genome_designer/main/templates/reference_genome.html
+++ b/genome_designer/main/templates/reference_genome.html
@@ -1,7 +1,9 @@
 {% extends "tab_base.html" %}
 
 {% block content%}
-  <h1>Reference Genome: {{reference_genome.label}}</h1>
+  <div class="gd-header h1">
+    Reference Genome: {{reference_genome.label}}
+  </div>
 
   <a href="{{jbrowse_link}}" target="_blank">JBrowse</a>
 


### PR DESCRIPTION
Fixed the Reference Genomes header gap

Blerp. Gleb comment changes.

More changes

Trying to get stuff synced...

Syncing

Sync2

fixed size of field select in analyze variants view #149

don't want to change all the modals

Fixed size of field select in analyze variants view, 149.

fixed size of field select in analyze variants view #149

don't want to change all the modals
