### PR TITLE
Added variant set delete capability and fixed UI bug

### DIFF
--- a/genome_designer/main/static/js/variant_set_list_controls_component.js
+++ b/genome_designer/main/static/js/variant_set_list_controls_component.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Component that decorates the controls for the list of
+ *     Variant Sets.
+ */
+
+
+gd.VariantsetsControlsComponent = gd.DataTableControlsComponent.extend({
+  initialize: function() {
+    gd.DataTableControlsComponent.prototype.initialize.call(this);
+
+    if (!this.model) {
+      throw "VariantSetControlsComponent requires model.";
+    }
+    this.render();
+  },
+
+  render: function() {
+    this.decorateControls();
+  },
+
+  decorateControls: function() {
+    this.drawDropdownOptions();
+  },
+
+  /** Draws dropdown options. */
+  drawDropdownOptions: function() {
+    // Option to delete samples.
+    var deleteOptionHtml = (
+        '<a href="#" class="gd-id-variant-sets-delete">Delete</a>');
+    this.addDropdownOption(deleteOptionHtml);
+    $('.gd-id-variant-sets-delete').click(_.bind(this.handleDelete, this));
+  },
+
+  /** Sends request to delete selected samples. */
+  handleDelete: function() {
+    var variantSetUidList = this.datatableComponent.getCheckedRowUids();
+
+    // If nothing to do, show message.
+    if (!variantSetUidList.length) {
+      alert("Please select variant sets to delete.");
+      return;
+    }
+
+    // Get confirmation from user.
+    var agree = confirm("Are you sure you want delete these variant sets?");
+    if (!agree) {
+      return;
+    }
+
+    this.setUIStartLoadingState();
+
+    var postData = {
+        variantSetUidList: variantSetUidList,
+    };
+
+    $.post('/_/variants/delete', JSON.stringify(postData),
+        _.bind(this.handleDeleteResponse, this));
+  },
+
+  handleDeleteResponse: function(response) {
+    this.setUIDoneLoadingState();
+
+    if ('error' in response && response.error.length) {
+      alert(response.error);
+    } else {
+      this.trigger('MODELS_UPDATED');
+    }
+  },
+
+  /** Show loading feedback while loading. */
+  setUIStartLoadingState: function() {
+    this.loadingSpinner = new gd.Spinner();
+    this.loadingSpinner.spin()
+  },
+
+  /** Reset UI changes after loading complete.. */
+  setUIDoneLoadingState: function() {
+    if (this.loadingSpinner) {
+      this.loadingSpinner.stop();
+    }
+  },
+
+  destroy: function() {
+    $('#gd-variant-set-form-from-file-submit').unbind('click')
+    $('#gd-variant-set-form-empty-submit').unbind('click')
+    this.remove();
+    this.unbind();
+  }
+});

--- a/genome_designer/main/static/js/variant_set_list_view.js
+++ b/genome_designer/main/static/js/variant_set_list_view.js
@@ -12,6 +12,38 @@ gd.VariantSetListView = Backbone.View.extend({
 
   render: function() {
     $('#gd-sidenav-link-variant-sets').addClass('active');
+    this.redrawDatatable();
+  },
+
+  listenToControls: function() {
+    $('#gd-variant-set-form-from-file-submit').click(
+        _.bind(this.handleFormSubmitFromFile, this));
+    $('#gd-variant-set-form-empty-submit').click(
+        _.bind(this.handleFormSubmitEmpty, this));
+  },
+
+  decorateControls: function() {
+    this.variantsetsControlsComponent = new gd.VariantsetsControlsComponent({
+      el: '#gd-variant_set_list_view-datatable-hook-control',
+      model: this.model,
+      datatableComponent: this.datatableComponent
+    });
+
+    this.listenTo(this.variantsetsControlsComponent, 'MODELS_UPDATED',
+        _.bind(this.redrawDatatable, this));
+
+    this.listenToControls();
+  },
+
+  /** Draws or redraws the table. */
+  redrawDatatable: function() {
+    if (this.datatableComponent) {
+      this.datatableComponent.destroy();
+    }
+
+    if (this.variantsetsControlsComponent) {
+      this.variantsetsControlsComponent.destroy();
+    }
 
     this.datatableComponent = new gd.DataTableComponent({
         el: $('#gd-variant_set_list_view-datatable-hook'),
@@ -21,14 +53,7 @@ gd.VariantSetListView = Backbone.View.extend({
     });
 
     this.listenTo(this.datatableComponent, 'DONE_CONTROLS_REDRAW',
-        _.bind(this.listenToControls, this));
-  },
-
-  listenToControls: function() {
-    $('#gd-variant-set-form-from-file-submit').click(
-        _.bind(this.handleFormSubmitFromFile, this));
-    $('#gd-variant-set-form-empty-submit').click(
-        _.bind(this.handleFormSubmitEmpty, this));
+        _.bind(this.decorateControls, this));
   },
 
   /**

--- a/genome_designer/main/templates/base.html
+++ b/genome_designer/main/templates/base.html
@@ -62,6 +62,7 @@
   <script type="text/javascript" src="{% static "js/ref_genome_maker_modal.js" %}"></script>
   <script type="text/javascript" src="{% static "js/sample_list_controls_component.js" %}"></script>
   <script type="text/javascript" src="{% static "js/alignment_list_controls_component.js" %}"></script>
+  <script type="text/javascript" src="{% static "js/variant_set_list_controls_component.js" %}"></script>
   <script type="text/javascript" src="{% static "js/variant_field_select_component.js" %}"></script>
   <script type="text/javascript" src="{% static "js/variants_table_component.js" %}"></script>
 

--- a/genome_designer/main/templates/controls/variant_set_list_controls.html
+++ b/genome_designer/main/templates/controls/variant_set_list_controls.html
@@ -1,7 +1,7 @@
 <!-- Controls -->
 <div id='{{table_id}}-control' class="gd-datatable-control btn-group">
   <a class="btn dropdown-toggle btn-primary" data-toggle="dropdown" href="#">
-    Create New
+    New
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu">

--- a/genome_designer/main/xhr_handlers.py
+++ b/genome_designer/main/xhr_handlers.py
@@ -263,7 +263,7 @@ def variant_sets_delete(request):
     request_data = json.loads(request.body)
     variant_set_uid_list = request_data.get('variantSetUidList')
 
-    #First make sure all the sets belong to this user.
+    # First make sure all the sets belong to this user.
     variant_sets_to_delete = VariantSet.objects.filter(
         reference_genome__project__owner=request.user.get_profile(),
         uid__in=variant_set_uid_list)
@@ -271,10 +271,10 @@ def variant_sets_delete(request):
     if not len(variant_sets_to_delete) == len(variant_set_uid_list):
         raise Http404
 
-    #Validation succcessful, delete
+    # Validation succcessful, delete
     variant_sets_to_delete.delete()
 
-    #Return success response
+    # Return success response
     return HttpResponse(json.dumps({}), content_type='application/json')
 
 
@@ -1087,19 +1087,22 @@ def _create_variant_set_empty(ref_genome, variant_set_name):
     exists_set_with_same_name = bool(VariantSet.objects.filter(
         reference_genome=ref_genome,
         label=variant_set_name).count())
+
     if exists_set_with_same_name:
         error_string = 'Variant set %s exists' % variant_set_name
+        result = {
+            'error': error_string,
+        }
     else:
         error_string = ''
+        empty_variant_set = VariantSet.objects.create(
+                reference_genome=ref_genome,
+                label=variant_set_name)
+        result = {
+            'error': error_string,
+            'variantSetUid': empty_variant_set.uid
+        }
 
-    empty_variant_set = VariantSet.objects.create(
-            reference_genome=ref_genome,
-            label=variant_set_name)
-
-    result = {
-        'error': error_string,
-        'variantSetUid': empty_variant_set.uid
-    }
     return result
 
 


### PR DESCRIPTION
Note: binding the click event with .click can be done multiple times to the same element, so when deleting and recreating the element, unbind the .click upon destruction so that when rebinding the .click it does not become doubly bound.

UI bug: Users were given an error message when attempting to create a variant set with the same name as an existing one for the same reference genome, but the variant set was still created.
