### PR TITLE
Fixed bwa alignment pipeline to work with single fastqs

### DIFF
--- a/genome_designer/pipeline/pipeline_runner.py
+++ b/genome_designer/pipeline/pipeline_runner.py
@@ -294,6 +294,13 @@ def start_variant_calling_pipeline_task(alignment_group):
             bwa_dataset = sa_fresh.dataset_set.get(label=Dataset.TYPE.BWA_ALIGN)
             if bwa_dataset.status == Dataset.STATUS.FAILED:
                 failed = True
+                # # DEBUG: Uncomment to see alignment error output
+                # print '---------------ALIGNMENT ERROR OUTPUT---------------\n'
+                # error_dataset = sa_fresh.dataset_set.get(
+                #         label=Dataset.TYPE.BWA_ALIGN_ERROR)
+                # with open(error_dataset.get_absolute_location(),'r') as fh:
+                #     for line in fh:
+                #         print line
                 break
 
             if not bwa_dataset.status == Dataset.STATUS.READY:

--- a/genome_designer/pipeline/tests/test_pipeline.py
+++ b/genome_designer/pipeline/tests/test_pipeline.py
@@ -60,6 +60,15 @@ class TestAlignmentPipeline(TransactionTestCase):
         copy_and_add_dataset_source(self.experiment_sample, Dataset.TYPE.FASTQ2,
                 Dataset.TYPE.FASTQ2, TEST_FASTQ2)
 
+        # Create a sample with a single fastq
+        self.experiment_sample_single_fastq = ExperimentSample.objects.create(
+                project=self.project, label='sample_single_fastq')
+
+        # Add the fastq file to the sample
+        copy_and_add_dataset_source(self.experiment_sample_single_fastq,
+                Dataset.TYPE.FASTQ1, Dataset.TYPE.FASTQ1, TEST_FASTQ1)
+
+
     def test_run_pipeline(self):
         """End-to-end test of pipeline. Fails if any errors.
         """
@@ -103,3 +112,19 @@ class TestAlignmentPipeline(TransactionTestCase):
 
         with self.assertRaises(AssertionError):
             run_pipeline('name_placeholder', self.reference_genome, sample_list)
+
+    def test_run_pipeline__single_fastq(self):
+        """End-to-end test of pipeline with single fastq sample.
+        Fails if any errors.
+        """
+        sample_list = [self.experiment_sample_single_fastq]
+        result = run_pipeline(
+                'name_placeholder', self.reference_genome, sample_list)
+        alignment_group = result[0]
+        alignment_async_result = result[1]
+        variant_calling_async_result = result[2]
+        alignment_async_result.get()
+        variant_calling_async_result.get()
+        alignment_group = AlignmentGroup.objects.get(uid=alignment_group.uid)
+        self.assertEqual(AlignmentGroup.STATUS.COMPLETED,
+                alignment_group.status)


### PR DESCRIPTION
Had to fix detection of single fastq as well as changing the sam processing mask to leave out the compute insert metrics step as this uses a lumpy script that is meant for paired end reads